### PR TITLE
Fixing nuked URL with a better URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ title: Home
       <li>IE10 does have Flexbox support, but for an <a href="http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/">older version</a> of the current spec (<code>display:flexbox</code>).</li>
       <li>Safari 6 and below support the <a href="http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/">original and now obsolete</a> Flexbox syntax (<code>display:box</code>).</li>
       <li>Firefox does not support multi-line flexboxes. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=702508">this bug</a> for more details.</li>
-      <li>Opera, IE, and Safari require vendor prefixes. See <a href="http://caniuse.com/flexbox">caniuse.com</a> for more details.</li>
+      <li>Opera, IE, and Safari require vendor prefixes. See <a href="http://caniuse.com/#feat=flexbox">caniuse.com</a> for more details.</li>
     </ul>
   </section>
 


### PR DESCRIPTION
Hi,

The URL got nuked back to blank in the typo updates (I assume because the online editor forked slightly before the latest change); but the caniuse.com URL was a search one anyway, this goes to the proper full-time flexbox page.

Uses http://caniuse.com/flexbox instead of http://caniuse.com/#feat=flexbox

Cheers!
Darian
