### PR TITLE
Fixed HTML height for sticky footer css

### DIFF
--- a/demos/sticky-footer/index.html
+++ b/demos/sticky-footer/index.html
@@ -30,7 +30,12 @@ title: Sticky Footer
 
     <h2>The CSS</h2>
 
-<pre class="highlight"><code class="language-css">.Site {
+<pre class="highlight"><code class="language-css">
+html {
+  height: 100%;
+}
+
+.Site {
   display: flex;
   min-height: 100vh;
   flex-direction: column;


### PR DESCRIPTION
Adds the line to the sticky footer page. A comment may need to be added to clarify why it is required.
