### PR TITLE
Add values for flex-shrink and flex-basis to sticky footer example code.

### DIFF
--- a/demos/sticky-footer/index.html
+++ b/demos/sticky-footer/index.html
@@ -37,7 +37,7 @@ title: Sticky Footer
 }
 
 .Site-content {
-  flex: 1;
+  flex: 1 0 auto;
 }</code></pre>
 
     <p class="u-smaller">View the full <a href="https://github.com/philipwalton/solved-by-flexbox/blob/master/_sass/components/_site.scss">source</a> for the <code>Site</code> component used in this demo on Github.</p>


### PR DESCRIPTION
The sticky footer example should include explicit values for `flex-shrink` and `flex-basis`, as the default values in some browsers cause the content of the main section of the site to be cut-off.