### PR TITLE
fix box-sizing for firefox

### DIFF
--- a/assets/css/base/elements.css
+++ b/assets/css/base/elements.css
@@ -1,5 +1,5 @@
 *,
-*::after
+*::after,
 *::before {
   box-sizing: border-box;
 }


### PR DESCRIPTION
Error on Firefox 35 win and linux (and firefox dev ed 37.0a2)

__Without the fix:__
![screenshot from 2015-01-28 15 51 43](https://cloud.githubusercontent.com/assets/701648/5939630/a7062392-a705-11e4-8271-4f4f9a487d81.png)

__With the fix:__
![screenshot from 2015-01-28 15 51 58](https://cloud.githubusercontent.com/assets/701648/5939629/a7043258-a705-11e4-8df9-bcc052e3db26.png)
