### PR TITLE
Updating the flex value to match what is being used on the website

### DIFF
--- a/demos/sticky-footer.md
+++ b/demos/sticky-footer.md
@@ -40,7 +40,7 @@ In the example below, the container is set to the height of the window, and the 
 }
 
 .Site-content {
-  flex: 1;
+  flex: 1 0 auto;
 }
 ```
 


### PR DESCRIPTION
When using

    .Site-content {
      flex: 1;
    }

The footer will not be docked to the bottom, instead it will get to an absolute position based on the browser window height. Setting the value to `1 auto 0` will make it behave like expected.

This behavior can be seen if you use the devtools to edit the value to 1. It's surprisingly working fine in Chrome and Safari but it fails on IE.

Screenshot of the problem when using the value 1: http://prntscr.com/6wu5sz