### PR TITLE
Support the case where only one is rendered.

### DIFF
--- a/assets/css/components/input-add-on.css
+++ b/assets/css/components/input-add-on.css
@@ -33,3 +33,7 @@
 .InputAddOn-item:last-child {
   border-radius: 0 2px 2px 0;
 }
+.InputAddOn-field:only-child,
+.InputAddOn-item:only-child {
+  border-radius: 2px;
+}


### PR DESCRIPTION
In the case of only one item rendered, it would make sense to have the rounded border on all sides. Else we end up with only rounded border on right since it was the last to be applied.
