### PR TITLE
fix: fix IE11 Holy Grail by using explicit height

### DIFF
--- a/demos/holy-grail.md
+++ b/demos/holy-grail.md
@@ -41,7 +41,7 @@ Getting the center content row to stretch and the footer to stick to the bottom 
 ```css
 .HolyGrail {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
   flex-direction: column;
 }
 


### PR DESCRIPTION
I was working on this for work and stumbled upon this fix just now and thought I'd post it here. I tested on all browsers as well as older ones like IE11 and it seems to work fine. I'm not sure how, might be something to do with the flexbox algorithm. Here is a [Codepen example](https://codepen.io/souporserious/pen/PELgXB/). One caveat is the main content area needs an immediate nested element for additional flex layouts, but other than that it seems to work great.